### PR TITLE
Fix exception on open endpoints

### DIFF
--- a/lib/restroom.rb
+++ b/lib/restroom.rb
@@ -47,8 +47,7 @@ module Restroom
       Proc.new { |mode, response| response }
     end
 
-    def stack
-    end
+    def stack(config); end
 
     def connection
       @connection ||= Faraday.new endpoint do |config|


### PR DESCRIPTION
Unless the stack method is explicitly overloaded by the class that is including Restroom, method calls will fail because the connection method always passes it a Faraday::Connection object. While it would be necessary to overload the method for any APIs that require authentication, any open API will cause an exception unless an overload is created that simply accepts the config and then does nothing with it.