### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or install it yourself as:
 
 Here's the client code from the [Bitbucket2](http://github.com/fairfaxmedia/bitbucket2) gem:
 
-```
+```ruby
 module Bitbucket2
   class Client
     include Restroom
@@ -41,7 +41,7 @@ end
 
 ...and that's it - apart from some simple model files (for which I like to use Virtus):
 
-```
+```ruby
 module Bitbucket2
   class Commit
     include Virtus.model
@@ -59,6 +59,55 @@ The `exposes` invocation takes several options:
  - a class (model) to instantiate,
  - a id for building nested paths (so in the case of repositories we use the `full_name` attribute).
 
+### Authentication
+
+A Faraday::Connection object is passed into the `stack` method. This provides
+opportunity to configure options such as an authentication method:
+
+```ruby
+module ModuleName
+  class Client
+    include Restroom
+
+    AUTH_TOKEN = 'very_secure_token'
+
+    restroom 'https://my-domain.com' do
+      exposes :some_endpoint, model: ModelName
+    end
+
+    def self.stack(config)
+      config.token_auth(AUTH_TOKEN)
+    end
+  end
+end
+```
+
+See the [Faraday documentation](https://github.com/lostisland/faraday#authentication)
+for more examples.
+
+### Preparing responses
+
+Often times, the response from an API does not directly match the layout of your
+model (for example, the object/s could be wrapped in a `data` key). In these
+situations, you can supply a `response_filter` either as a class method for all
+endpoints or in the `expose` invocation:
+
+```ruby
+module ModuleName
+  class Client
+    include Restroom
+
+    restroom 'https://my-domain.com' do
+      exposes :some_endpoint, model: ModelName, response_filter: proc { |_, data| data['some_key'] }
+    end
+
+    # Response like: { data: [{key: value}, {key: value}]}
+    def self.response_filter
+      proc { |_, data| data['data'] }
+    end
+  end
+end
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ module Bitbucket2
     include Restroom
 
     restroom 'https://api.bitbucket.org', base_path: '2.0' do
-      exposes :repositories, class: Repository, id: :full_name do
-        exposes :commits, class: Commit, id: :hash
-        exposes :pull_requests, resource: 'pullrequests', class: PullRequest do
-          exposes :commits, class: Commit, id: :hash
+      exposes :repositories, model: Repository, id: :full_name do
+        exposes :commits, model: Commit, id: :hash
+        exposes :pull_requests, resource: 'pullrequests', model: PullRequest do
+          exposes :commits, model: Commit, id: :hash
         end
       end
     end
@@ -56,7 +56,7 @@ end
 The `exposes` invocation takes several options:
 
  - a key which is used to build the relation methods (so we can call Bitbucket2::Client.new.repositories, in this case),
- - a class to instantiate,
+ - a class (model) to instantiate,
  - a id for building nested paths (so in the case of repositories we use the `full_name` attribute).
 
 


### PR DESCRIPTION
1. The `exposes` method accepts `model` as an optional parameter rather than
`class`.
1. Provide some information about using stack for configuration and response_filter
for preparing response data for the model.