### PR TITLE
Allow consumers to select and configure the Faraday adapter

### DIFF
--- a/lib/restroom.rb
+++ b/lib/restroom.rb
@@ -52,7 +52,9 @@ module Restroom
     def connection
       @connection ||= Faraday.new endpoint do |config|
         stack(config)
-        config.adapter Faraday.default_adapter
+
+        adapters = config.builder.handlers
+        config.adapter Faraday.default_adapter if adapters.empty?
       end
     end
   end


### PR DESCRIPTION
Hey, @simonhildebrandt, I'd love for you to weigh in on this. I'm pulling large quantities of data and have been finding I've been hitting the 60s timeout on Net::HTTP. When I tried adding in a Net:HTTP config in my app, Faraday throw a deprecation warning saying 1.0 wouldn't allow the duplicate setting of Middleware.

I find this solution a little nasty—do you know a better way?